### PR TITLE
Drop libkodiplatform and require libp8-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
+find_package(p8-platform REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR}
-                    ${kodiplatform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/lib/psflib
                     ${PROJECT_SOURCE_DIR}/lib/SSEQPlayer)
 
@@ -20,7 +20,7 @@ add_subdirectory(lib/SSEQPlayer)
 set(NCSF_SOURCES src/NCSFCodec.cpp
                  src/RingBuffer.cpp)
 
-set(DEPLIBS psflib SSEQPlayer)
+set(DEPLIBS ${p8-platform_LIBRARIES} psflib SSEQPlayer)
 
 build_addon(audiodecoder.ncsf NCSF DEPLIBS)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")


### PR DESCRIPTION
No add-on bump need, I think