### PR TITLE
[ci][travis] use newer ubuntu & xcode versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ matrix:
       sudo: required
       compiler: clang
     - os: osx
-      osx_image: xcode7.3
-    - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode9
 
 #
 # Some of the OS X images don't have cmake, contrary to what people

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ env:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       compiler: gcc
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       compiler: clang
     - os: osx


### PR DESCRIPTION
Xenial support isn't official yet (https://github.com/travis-ci/travis-ci/issues/7260#issuecomment-350631563), as trusty builds fail anyway it doesn't matter if builds sometimes fail.